### PR TITLE
Add py35 compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ DESCRIPTION = 'AES encryption for zipfile.'
 URL = 'https://github.com/danifus/pyzipper'
 EMAIL = 'daniel.hillier@gmail.com'
 AUTHOR = 'Daniel Hillier'
-REQUIRES_PYTHON = '>=3.3'
+REQUIRES_PYTHON = '>=3.5'
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'pycrypto',
+    'pycryptodomex',
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -105,6 +105,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     # $ setup.py publish support.
     cmdclass={

--- a/test/support/__init__.py
+++ b/test/support/__init__.py
@@ -377,7 +377,7 @@ if sys.platform.startswith("win"):
                 try:
                     mode = os.lstat(fullname).st_mode
                 except OSError as exc:
-                    print("support.rmtree(): os.lstat(%r) failed with %s" % (fullname, exc),
+                    print("support.rmtree(): os.lstat({!r}) failed with {}".format(fullname, exc),
                           file=sys.__stderr__)
                     mode = 0
                 if stat.S_ISDIR(mode):
@@ -589,8 +589,9 @@ def _requires_unix_version(sysname, min_version):
                     if version < min_version:
                         min_version_txt = '.'.join(map(str, min_version))
                         raise unittest.SkipTest(
-                            "%s version %s or higher required, not %s"
-                            % (sysname, min_version_txt, version_txt))
+                            "{} version {} or higher required, not {}".format(sysname,
+                                                                              min_version_txt,
+                                                                              version_txt))
             return func(*args, **kw)
         wrapper.min_version = min_version
         return wrapper
@@ -727,12 +728,12 @@ def bind_port(sock, host=HOST):
     if sock.family == socket.AF_INET and sock.type == socket.SOCK_STREAM:
         if hasattr(socket, 'SO_REUSEADDR'):
             if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR) == 1:
-                raise TestFailed("tests should never set the SO_REUSEADDR "   \
+                raise TestFailed("tests should never set the SO_REUSEADDR "
                                  "socket option on TCP/IP sockets!")
         if hasattr(socket, 'SO_REUSEPORT'):
             try:
                 if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) == 1:
-                    raise TestFailed("tests should never set the SO_REUSEPORT "   \
+                    raise TestFailed("tests should never set the SO_REUSEPORT "
                                      "socket option on TCP/IP sockets!")
             except OSError:
                 # Python's socket module was compiled using modern headers
@@ -987,8 +988,8 @@ def temp_dir(path=None, quiet=False):
         except OSError as exc:
             if not quiet:
                 raise
-            warnings.warn(f'tests may fail, unable to create '
-                          f'temporary directory {path!r}: {exc}',
+            warnings.warn('tests may fail, unable to create '
+                          'temporary directory {!r}: {}'.format(path, exc),
                           RuntimeWarning, stacklevel=3)
     if dir_created:
         pid = os.getpid()
@@ -1019,8 +1020,8 @@ def change_cwd(path, quiet=False):
     except OSError as exc:
         if not quiet:
             raise
-        warnings.warn(f'tests may fail, unable to change the current working '
-                      f'directory to {path!r}: {exc}',
+        warnings.warn('tests may fail, unable to change the current working '
+                      'directory to {!r}: {}'.format(path, exc),
                       RuntimeWarning, stacklevel=3)
     try:
         yield os.getcwd()
@@ -2134,7 +2135,7 @@ def threading_cleanup(*original_values):
                      values[0], len(dangling_threads)),
                   file=sys.stderr)
             for thread in dangling_threads:
-                print(f"Dangling thread: {thread!r}", file=sys.stderr)
+                print("Dangling thread: {!r}".format(thread), file=sys.stderr)
             sys.stderr.flush()
 
             # Don't hold references to threads
@@ -2186,9 +2187,10 @@ def wait_threads_exit(timeout=60.0):
                 break
             if time.monotonic() > deadline:
                 dt = time.monotonic() - start_time
-                msg = (f"wait_threads() failed to cleanup {count - old_count} "
-                       f"threads after {dt:.1f} seconds "
-                       f"(count: {count}, old count: {old_count})")
+                msg = ("wait_threads() failed to cleanup {} "
+                       "threads after {:.1f} seconds "
+                       "(count: {}, old count: {})".format(count - old_count,
+                                                           dt, count, old_count))
                 raise AssertionError(msg)
             time.sleep(0.010)
             gc_collect()
@@ -2200,7 +2202,7 @@ def join_thread(thread, timeout=30.0):
     """
     thread.join(timeout)
     if thread.is_alive():
-        msg = f"failed to join the thread in {timeout:.1f} seconds"
+        msg = "failed to join the thread in {:.1f} seconds".format(timeout)
         raise AssertionError(msg)
 
 
@@ -2923,7 +2925,7 @@ class FakePath:
         self.path = path
 
     def __repr__(self):
-        return f'<FakePath {self.path!r}>'
+        return '<FakePath {!r}>'.format(self.path)
 
     def __fspath__(self):
         if (isinstance(self.path, BaseException) or

--- a/test/support/testresult.py
+++ b/test/support/testresult.py
@@ -45,7 +45,7 @@ class RegressionTestResult(unittest.TextTestResult):
         self.__e = e = ET.SubElement(self.__suite, 'testcase')
         self.__start_time = time.perf_counter()
         if self.__verbose:
-            self.stream.write(f'{self.getDescription(test)} ... ')
+            self.stream.write('{} ... '.format(self.getDescription(test)))
             self.stream.flush()
 
     def _add_result(self, test, capture=False, **args):
@@ -57,7 +57,7 @@ class RegressionTestResult(unittest.TextTestResult):
         e.set('status', args.pop('status', 'run'))
         e.set('result', args.pop('result', 'completed'))
         if self.__start_time:
-            e.set('time', f'{time.perf_counter() - self.__start_time:0.6f}')
+            e.set('time', '{:0.6f}'.format(time.perf_counter() - self.__start_time))
 
         if capture:
             stdout = self._stdout_buffer.getvalue().rstrip()
@@ -80,7 +80,7 @@ class RegressionTestResult(unittest.TextTestResult):
 
     def __write(self, c, word):
         if self.__verbose:
-            self.stream.write(f'{word}\n')
+            self.stream.write('{}\n'.format(word))
 
     @classmethod
     def __makeErrorDict(cls, err_type, err_value, err_tb):
@@ -88,7 +88,7 @@ class RegressionTestResult(unittest.TextTestResult):
             if err_type.__module__ == 'builtins':
                 typename = err_type.__name__
             else:
-                typename = f'{err_type.__module__}.{err_type.__name__}'
+                typename = '{}.{}'.format(err_type.__module__, err_type.__name__)
         else:
             typename = repr(err_type)
 
@@ -119,7 +119,7 @@ class RegressionTestResult(unittest.TextTestResult):
     def addSkip(self, test, reason):
         self._add_result(test, skipped=reason)
         super().addSkip(test, reason)
-        self.__write('S', f'skipped {reason!r}')
+        self.__write('S', 'skipped {!r}'.format(reason))
 
     def addSuccess(self, test):
         self._add_result(test)
@@ -140,9 +140,9 @@ class RegressionTestResult(unittest.TextTestResult):
     def printErrorList(self, flavor, errors):
         for test, err in errors:
             self.stream.write(self.separator1)
-            self.stream.write(f'{flavor}: {self.getDescription(test)}\n')
+            self.stream.write('{}: {}\n'.format(flavor, self.getDescription(test)))
             self.stream.write(self.separator2)
-            self.stream.write('%s\n' % err)
+            self.stream.write('{}\n'.format(err))
 
     def get_xml_element(self):
         e = self.__suite

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -163,8 +163,8 @@ class TestSupport(unittest.TestCase):
 
         self.assertEqual(len(warnings), 1, warnings)
         warn = warnings[0]
-        self.assertTrue(warn.startswith(f'tests may fail, unable to create '
-                                        f'temporary directory {path!r}: '),
+        self.assertTrue(warn.startswith('tests may fail, unable to create '
+                                        'temporary directory {!r}: '.format(path)),
                         warn)
 
     @unittest.skipUnless(hasattr(os, "fork"), "test requires os.fork")
@@ -235,9 +235,9 @@ class TestSupport(unittest.TestCase):
 
         self.assertEqual(len(warnings), 1, warnings)
         warn = warnings[0]
-        self.assertTrue(warn.startswith(f'tests may fail, unable to change '
-                                        f'the current working directory '
-                                        f'to {bad_dir!r}: '),
+        self.assertTrue(warn.startswith('tests may fail, unable to change '
+                                        'the current working directory '
+                                        'to {!r}: '.format(bad_dir)),
                         warn)
 
     # Tests for change_cwd()
@@ -252,9 +252,9 @@ class TestSupport(unittest.TestCase):
 
         self.assertEqual(len(messages), 1, messages)
         msg = messages[0]
-        self.assertTrue(msg.startswith(f'tests may fail, unable to change '
-                                       f'the current working directory '
-                                       f'to {path!r}: '),
+        self.assertTrue(msg.startswith('tests may fail, unable to change '
+                                       'the current working directory '
+                                       'to {!r}: '.format(path)),
                         msg)
 
     # Tests for temp_cwd()
@@ -457,7 +457,7 @@ class TestSupport(unittest.TestCase):
         support.reap_children()
 
     def check_options(self, args, func):
-        code = f'from test.support import {func}; print(repr({func}()))'
+        code = 'from test.support import {}; print(repr({}()))'.format(func, func)
         cmd = [sys.executable, *args, '-c', code]
         env = {key: value for key, value in os.environ.items()
                if not key.startswith('PYTHON')}

--- a/test/test_zipfile.py
+++ b/test/test_zipfile.py
@@ -1,6 +1,7 @@
 import contextlib
 import io
 import os
+import sys
 import importlib.util
 import pathlib
 import posixpath
@@ -1066,6 +1067,9 @@ class ExtractTests(unittest.TestCase):
         with zipfile.ZipFile(TESTFN2, "r") as zipfp:
             for fpath, fdata in SMALL_TEST_DATA:
                 writtenfile = zipfp.extract(fpath, target)
+                # compat with Path objects were added in python 3.6
+                if sys.version_info[0:2] < (3, 6):
+                    target = str(target)
 
                 # make sure it was written to the right place
                 correctfile = os.path.join(target, fpath)
@@ -1106,7 +1110,10 @@ class ExtractTests(unittest.TestCase):
         with zipfile.ZipFile(TESTFN2, "r") as zipfp:
             zipfp.extractall(target)
             for fpath, fdata in SMALL_TEST_DATA:
-                outfile = os.path.join(target, fpath)
+                # compat with Path objects were added in python 3.6
+                if sys.version_info[0:2] < (3, 6):
+                    target = str(target)
+                outfile = os.path.join(str(target), fpath)
 
                 with open(outfile, "rb") as f:
                     self.assertEqual(fdata.encode(), f.read())

--- a/test/test_zipfile2.py
+++ b/test/test_zipfile2.py
@@ -4,6 +4,7 @@ zipfile_aes.AESZipFile object instead of the zipfile.ZipFile object.
 import contextlib
 import io
 import os
+import sys
 import importlib.util
 import pathlib
 import posixpath
@@ -1070,6 +1071,9 @@ class ExtractTests(unittest.TestCase):
         with zipfile_aes.AESZipFile(TESTFN2, "r") as zipfp:
             for fpath, fdata in SMALL_TEST_DATA:
                 writtenfile = zipfp.extract(fpath, target)
+                # compat with Path objects were added in python 3.6
+                if sys.version_info[0:2] < (3, 6):
+                    target = str(target)
 
                 # make sure it was written to the right place
                 correctfile = os.path.join(target, fpath)
@@ -1110,7 +1114,10 @@ class ExtractTests(unittest.TestCase):
         with zipfile_aes.AESZipFile(TESTFN2, "r") as zipfp:
             zipfp.extractall(target)
             for fpath, fdata in SMALL_TEST_DATA:
-                outfile = os.path.join(target, fpath)
+                # compat with Path objects were added in python 3.6
+                if sys.version_info[0:2] < (3, 6):
+                    target = str(target)
+                outfile = os.path.join(str(target), fpath)
 
                 with open(outfile, "rb") as f:
                     self.assertEqual(fdata.encode(), f.read())

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,31 @@
 [tox]
-envlist = python3.3,python3.4,python3.5,python3.6,python3.7
+envlist = py{35,36,37}, flake8
+
+[flake8]
+max-line-length = 99
+
+[testenv:flake8]
+basepython = python
+deps = flake8
+commands = flake8 pyzipper tests
+
+[testenv:full]
+# use 'tox -e full' to run zipfile64 tests as well (takes long and needs 6GB drive space).
+setenv = PYTHONPATH = {toxinidir}
+passenv = *
+deps = -r{toxinidir}/requirements_dev.txt
+commands = pytest --cov=pyzipper --cov-config .coveragerc test/test_zipfile_aes.py test/test_zipfile2.py test/test_zipfile.py test/test_zipfile64.py
+
+[testenv:aes_only]
+# use 'tox -e aes_only' to to only test aes code.
+commands = pytest --cov=pyzipper --cov-config .coveragerc test/test_zipfile_aes.py test/test_zipfile2.py
+
+[testenv:zip_only]
+# use 'tox -e zip_only' to to only test aes code.
+commands = pytest --cov=pyzipper --cov-config .coveragerc test/test_zipfile.py
 
 [testenv]
-# use the cmd line arg extralargefile to run zipfile64 tests.
-commands = python run_tests.py {posargs}
+setenv = PYTHONPATH = {toxinidir}
+passenv = *
+deps = -r{toxinidir}/requirements_dev.txt
+commands = pytest --cov=pyzipper --cov-config .coveragerc test/test_zipfile_aes.py test/test_zipfile2.py test/test_zipfile.py


### PR DESCRIPTION
Adding compat for older python versions wasn't as simple as removing the f-strings, since `os.PathLike` and `os.fspath` ([see](https://docs.python.org/3/library/os.html#os.fspath)) were added in python 3.6 .
So there are a lot of version checks to treat Path objects different in py35.
I'm not sure if that is what you want so I put it in a different PR than #1 .

For py34 there are even differences in how it gets compiled and since it won't be supported after [March of 2019](https://www.python.org/dev/peps/pep-0429/), I don't think it's worth having the code overhead.