### PR TITLE
Set AESZipFile encryption default to WZ_AES

### DIFF
--- a/pyzipper/zipfile_aes.py
+++ b/pyzipper/zipfile_aes.py
@@ -333,7 +333,7 @@ class AESZipFile(ZipFile):
     zipextfile_cls = AESZipExtFile
 
     def __init__(self, *args, **kwargs):
-        encryption = kwargs.pop('encryption', None)
+        encryption = kwargs.pop('encryption', WZ_AES)
         encryption_kwargs = kwargs.pop('encryption_kwargs', None)
         super().__init__(*args, **kwargs)
         self.encryption = encryption


### PR DESCRIPTION
Hi @danifus 👋 , I was testing out pyzipper and ran into some unexpected behavior when writing a zipfile. e.g.,

```python
with pyzipper.AESZipFile("archive.zip", "w") as archive:
    archive.setpassword(b"password")
    with archive.open("file.txt", "w") as file:
        ...
 ```

The above resulted in this traceback:

```python
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "./.venv/lib/python3.9/site-packages/pyzipper/zipfile.py", line 2006, in open
    return self._open_to_write(zinfo, force_zip64=force_zip64, pwd=pwd)
  File "./.venv/lib/python3.9/site-packages/pyzipper/zipfile.py", line 2049, in _open_to_write
    encrypter.update_zipinfo(zinfo)
AttributeError: 'NoneType' object has no attribute 'update_zipinfo'
```

This was simply caused by my not specifying the `encryption` in the constructor, or via the `setencryption` method. However, it would seem sensible that `AESZipFile` would default to `encryption=WZ_AES`? Is there a reason why this shouldn't be the default? Thanks. 