### PR TITLE
Add partial encryption and deletion capabilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,13 @@ pyzipper
 ========
 
 A replacement for Python's ``zipfile`` that can read and write AES encrypted
-zip files. Forked from Python 3.7's ``zipfile`` module, it features the same
+zip files. Secure deletion of individual files from an existing ZIP archive
+is also supported.
+
+Forked from Python 3.7's ``zipfile`` module, it features the same
 ``zipfile`` API from that time (most notably, lacking support for
 ``pathlib``-compatible wrappers that were introduced in Python 3.8).
+
 
 Installation
 ------------
@@ -68,10 +72,66 @@ encryption kwargs:
        zf.setpassword(secret_password)
        my_secrets = zf.read('test.txt')
 
+
+Partial Encryption
+------------------
+
+It is possible to create archives which contain a mixture of encrypted
+and unencrypted files. This can be useful (for example) to include
+clear-text documentation or recovery instructions, within an otherwise
+secure archive.
+
+To add a clear-text file to an otherwise encrypted archive, pass
+``encrypt=False`` to ``open()``, ``write()`` or ``writestr()``.
+
+.. code-block:: python
+
+   import pyzipper
+
+   secret_password = b'lost art of keeping a secret'
+
+   with pyzipper.AESZipFile('new_test.zip',
+                            'w',
+                            compression=pyzipper.ZIP_LZMA) as zf:
+       zf.setpassword(secret_password)
+       zf.setencryption(pyzipper.WZ_AES, nbits=128)
+       zf.writestr('test.txt', "What ever you do, don't tell anyone!")
+       zf.writestr('README.txt', "Secrets enclosed!", encrypt=False)
+
+
+Deletion
+--------
+
+Deletion of individual files from within an existing archive is supported
+via the ``ZipFile.delete(filename)`` method.
+
+To replace an existing file, delete it first and then add a new one with
+the same name.
+
+Note that archives must be opened in with ``mode="a"`` (append), to allow
+modifications. Deleting from archives opened for reading is not supported,
+and opening with ``mode="w"`` or ``mode="x"`` will replace the entire ZIP
+archive with an empty one (so there will be nothing to delete).
+
+The algorithm used for deletion defaults to secure behavior, where data is
+immediately overwritten with junk, then removed from the central directory
+index, and finally (upon close) the archive is rewritten to reclaim space.
+
+Secure deletion can be disabled by passing ``insecure_delete=True`` to the
+``ZipFile`` or ``AESZipFie`` constructors.
+
+It is possible to adjust how frequently the archive is rewritten, by passing
+``compacting_threshold=X`` to the constructor, where X is a float between 0
+and 1, representing how much of the archive can be "wasted space" before
+triggering a compaction. Manual compaction is also available using the
+``compact()`` method.
+
+
 Documentation
 -------------
 
 Official Python ZipFile documentation is available here: https://docs.python.org/3/library/zipfile.html
+
 
 Credits
 -------

--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -1720,7 +1720,7 @@ class ZipFile:
         else:
             if isinstance(file, pathlib.PurePath):
                 file = str(file)
-        if isinstance(file, str):
+        if isinstance(file, (str, bytes)):
             # No, it's a filename
             self._filePassed = 0
             self.filename = file

--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -2191,7 +2191,7 @@ class ZipFile:
                                    " would require ZIP64 extensions")
 
     def write(self, filename, arcname=None,
-              compress_type=None, compresslevel=None):
+              compress_type=None, compresslevel=None, encrypt=True):
         """Put the bytes from filename into the archive under the name
         arcname."""
         if not self.fp:
@@ -2236,7 +2236,7 @@ class ZipFile:
                 self.fp.write(zinfo.FileHeader(False))
                 self.start_dir = self.fp.tell()
         else:
-            with open(filename, "rb") as src, self.open(zinfo, 'w') as dest:
+            with open(filename, "rb") as src, self.open(zinfo, 'w', encrypt=encrypt) as dest:
                 shutil.copyfileobj(src, dest, 1024*8)
 
     def writestr(self, zinfo_or_arcname, data,

--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -2008,7 +2008,9 @@ class ZipFile:
 
         if mode == 'w':
             return self._open_to_write(zinfo,
-                force_zip64=force_zip64, pwd=pwd, encrypt=encrypt)
+                                       force_zip64=force_zip64,
+                                       pwd=pwd,
+                                       encrypt=encrypt)
 
         if self._writing:
             raise ValueError("Can't read from the ZIP file while there "
@@ -2565,14 +2567,13 @@ class ZipFileRW(ZipFile):
                            wasting space. It will also leave "DELETED"
                            entries the directory until compacted.
     """
-    DELETED_JUNK   = b'DELETED!' * 1024
+    DELETED_JUNK = b'DELETED!' * 1024
     DELETED_FN_FMT = 'DELETED/%s'
 
     # Subclasses can override these to adjust defaults, which will make
     # sense for apps that know what their use profile is.
     INSECURE_DELETE = False
-    COMPACTING_THRESHOLD = 0.0   # Set to a ratio of allowable wasted space,
-                                 # to reduce the I/O overhead of deletion.
+    COMPACTING_THRESHOLD = 0.0
 
     def __init__(self, *args, **kwargs):
         """

--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -2777,7 +2777,7 @@ class ZipFileRW(ZipFile):
                 self._writing = False
 
     def _write_end_record(self):
-        if not self.insecure_delete:
+        if not self.insecure_delete and self.compacting_threshold is not False:
             self.compact(threshold=self.compacting_threshold)
         return super()._write_end_record()
 

--- a/pyzipper/zipfile_aes.py
+++ b/pyzipper/zipfile_aes.py
@@ -13,6 +13,7 @@ from .zipfile import (
     BadZipFile,
     BaseZipDecrypter,
     ZipFile,
+    ZipFileRW,
     ZipInfo,
     ZipExtFile,
 )
@@ -328,7 +329,7 @@ class AESZipExtFile(ZipExtFile):
             super().check_integrity()
 
 
-class AESZipFile(ZipFile):
+class AESZipFile(ZipFileRW):
     zipinfo_cls = AESZipInfo
     zipextfile_cls = AESZipExtFile
 

--- a/pyzipper/zipfile_aes.py
+++ b/pyzipper/zipfile_aes.py
@@ -12,7 +12,6 @@ from .zipfile import (
     ZIP_LZMA,
     BadZipFile,
     BaseZipDecrypter,
-    ZipFile,
     ZipFileRW,
     ZipInfo,
     ZipExtFile,

--- a/pyzipper/zipfile_aes.py
+++ b/pyzipper/zipfile_aes.py
@@ -192,6 +192,15 @@ class AESZipInfo(ZipInfo):
         self.wz_aes_vendor_id = None
         self.wz_aes_strength = None
 
+    def __repr__(self):
+        r = [super().__repr__()[:-1]]
+        r.extend([
+             ' wz_aes_version=%s' % self.wz_aes_version,
+             ' wz_aes_vendor_id=%s' % self.wz_aes_vendor_id,
+             ' wz_aes_strength=%s' % self.wz_aes_strength,
+             '>'])
+        return ''.join(r)
+
     def decode_extra_wz_aes(self, ln, extra):
         if ln == 7:
             counts = struct.unpack("<H2sBH", extra[4: ln+4])
@@ -292,7 +301,7 @@ class AESZipExtFile(ZipExtFile):
         return AESZipDecrypter
 
     def setup_decrypter(self):
-        if self._zinfo.wz_aes_version is not None:
+        if self._zinfo.wz_aes_vendor_id is not None:
             return self.setup_aeszipdecrypter()
         return super().setup_decrypter()
 

--- a/test/test_zipfile.py
+++ b/test/test_zipfile.py
@@ -152,6 +152,12 @@ class AbstractTestsWithSourceFile:
         for f in get_files(self):
             self.zip_open_test(f, self.compression)
 
+    def test_open_with_bytes(self):
+        path = bytes(TESTFN2, 'utf-8')
+        self.zip_open_test(path, self.compression)
+        with zipfile.ZipFile(path, "r", self.compression) as zipfp:
+            self.assertIsInstance(zipfp.filename, bytes)
+
     def test_open_with_pathlike(self):
         path = pathlib.Path(TESTFN2)
         self.zip_open_test(path, self.compression)

--- a/test/test_zipfile.py
+++ b/test/test_zipfile.py
@@ -1053,13 +1053,14 @@ class LzmaTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
 
 
 class AbstractWriterTests:
+    ZIPFILE_CLS = zipfile.ZipFile
 
     def tearDown(self):
         unlink(TESTFN2)
 
     def test_close_after_close(self):
         data = b'content'
-        with zipfile.ZipFile(TESTFN2, "w", self.compression) as zipf:
+        with self.ZIPFILE_CLS(TESTFN2, "w", self.compression) as zipf:
             w = zipf.open('test', 'w')
             w.write(data)
             w.close()
@@ -1070,7 +1071,7 @@ class AbstractWriterTests:
 
     def test_write_after_close(self):
         data = b'content'
-        with zipfile.ZipFile(TESTFN2, "w", self.compression) as zipf:
+        with self.ZIPFILE_CLS(TESTFN2, "w", self.compression) as zipf:
             w = zipf.open('test', 'w')
             w.write(data)
             w.close()
@@ -1092,6 +1093,92 @@ class Bzip2WriterTests(AbstractWriterTests, unittest.TestCase):
 @requires_lzma
 class LzmaWriterTests(AbstractWriterTests, unittest.TestCase):
     compression = zipfile.ZIP_LZMA
+
+
+class ZipFileRWTests(AbstractWriterTests, unittest.TestCase):
+    compression = zipfile.ZIP_STORED
+    ZIPFILE_CLS = zipfile.ZipFileRW
+
+    def test_delete_secure(self):
+        junk = self.ZIPFILE_CLS.DELETED_JUNK[:10]
+        data = b'content'
+        kwargs = {
+            'compression': self.compression,
+            'insecure_delete': False,       # Secure deletion please!
+            'compacting_threshold': False}  # Disable auto-compaction
+
+        with self.ZIPFILE_CLS(TESTFN2, "w", **kwargs) as zipf:
+            with zipf.open('test', 'w') as w:
+                w.write(data)
+            with zipf.open('test2', 'w') as w:
+                w.write(data * 2)
+            with zipf.open('test3', 'w') as w:
+                w.write(data * 3)
+
+        with self.ZIPFILE_CLS(TESTFN2, "a", **kwargs) as zipf:
+            self.assertEqual(zipf.read('test'), data)
+            zipf.delete('test')
+            try:
+                zipf.read('test')
+                self.assertFalse('not reached')
+            except KeyError:
+                pass  # Great, deletion worked!
+            with zipf.open('test4', 'w') as w:
+                w.write(data * 4)
+
+        with open(TESTFN2, 'rb') as raw:
+            self.assertTrue(junk in raw.read())
+
+        with self.ZIPFILE_CLS(TESTFN2, "a", **kwargs) as zipf:
+            try:
+                zipf.read('test')
+                self.assertFalse('not reached')
+            except KeyError:
+                pass  # Great, deletion worked!
+            self.assertEqual(zipf.read('test2'), data * 2)
+            self.assertEqual(zipf.read('test3'), data * 3)
+            self.assertEqual(zipf.read('test4'), data * 4)
+            zipf.compact()
+            zipf.delete('test4')
+
+        with open(TESTFN2, 'rb') as raw:
+            # We compacted, and then deleted the LAST file in the archive
+            # (which auto-truncates), so the archive should have no junk.
+            self.assertTrue(junk not in raw.read())
+
+        with self.ZIPFILE_CLS(TESTFN2, "a", **kwargs) as zipf:
+            self.assertEqual(zipf.read('test2'), data * 2)
+            self.assertEqual(zipf.read('test3'), data * 3)
+
+    def test_delete_insecure(self):
+        junk = self.ZIPFILE_CLS.DELETED_JUNK[:10]
+        data1 = b'insecure'
+        data2 = b'content'
+        kwargs = {
+            'compression': self.compression,
+            'insecure_delete': True}
+
+        with self.ZIPFILE_CLS(TESTFN2, "w", **kwargs) as zipf:
+            with zipf.open('test1', 'w') as w:
+                w.write(data1)
+            with zipf.open('test2', 'w') as w:
+                w.write(data2)
+
+        with self.ZIPFILE_CLS(TESTFN2, "a", **kwargs) as zipf:
+            self.assertEqual(zipf.read('test1'), data1)
+            self.assertEqual(zipf.read('test2'), data2)
+            zipf.delete('test1')
+            try:
+                zipf.read('test1')
+                self.assertFalse('not reached')
+            except KeyError:
+                pass  # Great, deletion worked!
+            zipf.compact()  # Shouldn't do much of anything
+
+        with open(TESTFN2, 'rb') as raw:
+            raw_data = raw.read()
+            self.assertTrue(data1 in raw_data)  # The raw data is still there
+            self.assertTrue(junk not in raw_data)
 
 
 @unittest.skipIf(sys.version_info[0:2] < (3, 5), 'Requires Python >= 3.5')

--- a/test/test_zipfile_aes.py
+++ b/test/test_zipfile_aes.py
@@ -580,7 +580,7 @@ class AbstractTestsWithRandomBinaryFiles:
             if partial_enc:
                 testdata = zipfp.read(TESTFN)  # Unencrypted: succeeds
                 try:
-                    unreadable = zipfp.read('another.name')  # Encrypted: fails
+                    zipfp.read('another.name')  # Encrypted: should fail
                     self.assertFalse('not reached')
                 except RuntimeError:
                     pass  # Good! Reading encrypted data failed.
@@ -751,7 +751,7 @@ class AbstractTestZip64InSmallFiles:
 
             directory = fp.getvalue()
             lines = directory.splitlines()
-            self.assertEqual(len(lines), 4) # Number of files + header
+            self.assertEqual(len(lines), 4)  # Number of files + header
 
             self.assertIn('File Name', lines[0])
             self.assertIn('Modified', lines[0])


### PR DESCRIPTION
This is an attempt at solving #32.

There are two main features added here: partial encryption, and (secure) deletion of files from within an archive.

The rationale for partial encryption: I want to create ZIP archives which are encrypted, but also have one or two clear-text files which can be accessed without the password. In my use-case, these files will contain Passcrow (<https://passcrow.org/>) recovery data, to make it possible to decrypt an archive even if the password has been lost.

The rationale for deletion: I want to be able to efficiently and securely edit ZIP files in-place, instead of creating a new ZIP archive from scratch every time something changes.

As requested in the issue, the behavior is unchanged by default: You only get mixed-encryption files if you pass a new `encrypt=False` parameter to `open()` or `write()` methods. Deletion never happen unless the developer explicitly requests it, and compaction only happens if something has been deleted. In particular, attempting to write to an exiting file will still raise an error as before, the developer has to manually delete it first if they want to replace the contents.

I've documented the features and added tests for everything. I think flake8 is happy with my changes.

Apologies for submitting both features in a single PR - the partial encryption is quite trivial, so I hope that is OK.

What do you think?