### PR TITLE
Add support for zstd compression

### DIFF
--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -34,6 +34,11 @@ try:
 except ImportError:
     lzma = None
 
+try:
+    from compression import zstd  # We may need its compression method
+except ImportError:
+    zstd = None
+
 __all__ = ["BadZipFile", "BadZipfile", "error",
            "ZIP_STORED", "ZIP_DEFLATED", "ZIP_BZIP2", "ZIP_LZMA",
            "is_zipfile", "ZipInfo", "ZipFile", "PyZipFile", "LargeZipFile"]
@@ -62,12 +67,14 @@ ZIP_STORED = 0
 ZIP_DEFLATED = 8
 ZIP_BZIP2 = 12
 ZIP_LZMA = 14
+ZIP_ZSTANDARD = 93
 # Other ZIP compression methods not supported
 
 DEFAULT_VERSION = 20
 ZIP64_VERSION = 45
 BZIP2_VERSION = 46
 LZMA_VERSION = 63
+ZSTANDARD_VERSION = 63
 # we recognize (but not necessarily support) all features up to that version
 MAX_EXTRACT_VERSION = 63
 
@@ -607,6 +614,8 @@ class ZipInfo (object):
             min_version = max(BZIP2_VERSION, min_version)
         elif self.compress_type == ZIP_LZMA:
             min_version = max(LZMA_VERSION, min_version)
+        elif self.compress_type == ZIP_ZSTANDARD:
+            min_version = max(ZSTANDARD_VERSION, min_version)
 
         self.extract_version = max(min_version, self.extract_version)
         self.create_version = max(min_version, self.create_version)
@@ -685,6 +694,8 @@ class ZipInfo (object):
             min_version = max(BZIP2_VERSION, min_version)
         elif self.compress_type == ZIP_LZMA:
             min_version = max(LZMA_VERSION, min_version)
+        elif self.compress_type == ZIP_ZSTANDARD:
+            min_version = max(ZSTANDARD_VERSION, min_version)
 
         extract_version = max(min_version, self.extract_version)
         create_version = max(min_version, self.create_version)
@@ -1039,6 +1050,7 @@ compressor_names = {
     14: 'lzma',
     18: 'terse',
     19: 'lz77',
+    93: 'zstd',
     97: 'wavpack',
     98: 'ppmd',
 }
@@ -1059,6 +1071,10 @@ def _check_compression(compression):
         if not lzma:
             raise RuntimeError(
                 "Compression requires the (missing) lzma module")
+    elif compression == ZIP_ZSTANDARD:
+        if not zstd:
+            raise RuntimeError(
+                "Compression requires the (missing) compression.zstd module")
     else:
         raise NotImplementedError("That compression method is not supported")
 
@@ -1072,9 +1088,11 @@ def _get_compressor(compress_type, compresslevel=None):
         if compresslevel is not None:
             return bz2.BZ2Compressor(compresslevel)
         return bz2.BZ2Compressor()
-    # compresslevel is ignored for ZIP_LZMA
+    # compresslevel is ignored for ZIP_LZMA and ZIP_ZSTANDARD
     elif compress_type == ZIP_LZMA:
         return LZMACompressor()
+    elif compress_type == ZIP_ZSTANDARD:
+        return zstd.ZstdCompressor()
     else:
         return None
 
@@ -1268,6 +1286,8 @@ class ZipExtFile(io.BufferedIOBase):
             return bz2.BZ2Decompressor()
         elif compress_type == ZIP_LZMA:
             return LZMADecompressor()
+        elif compress_type == ZIP_ZSTANDARD:
+            return zstd.ZstdDecompressor()
         else:
             descr = compressor_names.get(compress_type)
             if descr:
@@ -1672,7 +1692,8 @@ class ZipFile:
     mode: The mode can be either read 'r', write 'w', exclusive create 'x',
           or append 'a'.
     compression: ZIP_STORED (no compression), ZIP_DEFLATED (requires zlib),
-                 ZIP_BZIP2 (requires bz2) or ZIP_LZMA (requires lzma).
+                 ZIP_BZIP2 (requires bz2), ZIP_LZMA (requires lzma), or
+                 ZIP_ZSTANDARD (requires compression.zstd).
     allowZip64: if True ZipFile will create files with ZIP64 extensions when
                 needed, otherwise it will raise an exception when this would
                 be necessary.
@@ -1681,6 +1702,9 @@ class ZipFile:
                    When using ZIP_STORED or ZIP_LZMA this keyword has no effect.
                    When using ZIP_DEFLATED integers 0 through 9 are accepted.
                    When using ZIP_BZIP2 integers 1 through 9 are accepted.
+                   When using ZIP_ZSTANDARD integers -7 though 22 are common,
+                   see the CompressionParameter enum in compression.zstd for
+                   details.
 
     """
 

--- a/pyzipper/zipfile.py
+++ b/pyzipper/zipfile.py
@@ -41,7 +41,8 @@ except ImportError:
 
 __all__ = ["BadZipFile", "BadZipfile", "error",
            "ZIP_STORED", "ZIP_DEFLATED", "ZIP_BZIP2", "ZIP_LZMA",
-           "is_zipfile", "ZipInfo", "ZipFile", "PyZipFile", "LargeZipFile"]
+           "ZIP_ZSTANDARD", "is_zipfile", "ZipInfo", "ZipFile",
+           "PyZipFile", "LargeZipFile"]
 
 
 class BadZipFile(Exception):
@@ -1088,11 +1089,11 @@ def _get_compressor(compress_type, compresslevel=None):
         if compresslevel is not None:
             return bz2.BZ2Compressor(compresslevel)
         return bz2.BZ2Compressor()
-    # compresslevel is ignored for ZIP_LZMA and ZIP_ZSTANDARD
+    # compresslevel is ignored for ZIP_LZMA
     elif compress_type == ZIP_LZMA:
         return LZMACompressor()
     elif compress_type == ZIP_ZSTANDARD:
-        return zstd.ZstdCompressor()
+        return zstd.ZstdCompressor(level=compresslevel)
     else:
         return None
 

--- a/test/support/__init__.py
+++ b/test/support/__init__.py
@@ -63,6 +63,11 @@ except ImportError:
     lzma = None
 
 try:
+    from compression import zstd
+except ImportError:
+    zstd = None
+
+try:
     import resource
 except ImportError:
     resource = None
@@ -89,7 +94,7 @@ __all__ = [
     "transient_internet", "BasicTestRunner", "run_unittest", "run_doctest",
     "skip_unless_symlink", "requires_gzip", "requires_bz2", "requires_lzma",
     "bigmemtest", "bigaddrspacetest", "cpython_only", "get_attribute",
-    "requires_IEEE_754", "skip_unless_xattr", "requires_zlib",
+    "requires_IEEE_754", "skip_unless_xattr", "requires_zlib", "requires_zstd",
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
     "check__all__", "skip_unless_bind_unix_socket",
     "ignore_warnings",
@@ -811,6 +816,8 @@ requires_gzip = unittest.skipUnless(gzip, 'requires gzip')
 requires_bz2 = unittest.skipUnless(bz2, 'requires bz2')
 
 requires_lzma = unittest.skipUnless(lzma, 'requires lzma')
+
+requires_zstd = unittest.skipUnless(zstd, 'requires zstd')
 
 is_jython = sys.platform.startswith('java')
 

--- a/test/test_zipfile.py
+++ b/test/test_zipfile.py
@@ -18,7 +18,7 @@ from random import randint, random, getrandbits
 from test.support import script_helper
 from test.support import (TESTFN, findfile, unlink, rmtree, temp_dir, temp_cwd,
                           requires_zlib, requires_bz2, requires_lzma,
-                          captured_stdout)
+                          requires_zstd, captured_stdout)
 
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"
@@ -598,6 +598,10 @@ class LzmaTestsWithSourceFile(AbstractTestsWithSourceFile,
                               unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdTestsWithSourceFile(AbstractTestsWithSourceFile,
+                              unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 class AbstractTestZip64InSmallFiles:
     # These tests test the ZIP64 functionality without using large files,
@@ -1051,6 +1055,10 @@ class LzmaTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                                 unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
+                                unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 class AbstractWriterTests:
 
@@ -1093,6 +1101,9 @@ class Bzip2WriterTests(AbstractWriterTests, unittest.TestCase):
 class LzmaWriterTests(AbstractWriterTests, unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdWriterTests(AbstractWriterTests, unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 @unittest.skipIf(sys.version_info[0:2] < (3, 5), 'Requires Python >= 3.5')
 class PyZipFileTests(unittest.TestCase):
@@ -2087,6 +2098,17 @@ class LzmaBadCrcTests(AbstractBadCrcTests, unittest.TestCase):
         b'ePK\x05\x06\x00\x00\x00\x00\x01\x00\x01\x003\x00\x00'
         b'\x00>\x00\x00\x00\x00\x00')
 
+@requires_zstd
+class ZstdBadCrcTests(AbstractBadCrcTests, unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
+    zip_with_bad_crc = (
+        b'PK\x03\x04?\x00\x00\x00]\x00\x00\x00!\x00V\xb1\x17J\x14\x00'
+        b'\x00\x00\x0b\x00\x00\x00\x05\x00\x00\x00afile(\xb5/\xfd\x00'
+        b'XY\x00\x00Hello WorldPK\x01\x02?\x03?\x00\x00\x00]\x00\x00\x00'
+        b'!\x00V\xb0\x17J\x14\x00\x00\x00\x0b\x00\x00\x00\x05\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x00\x00afilePK'
+        b'\x05\x06\x00\x00\x00\x00\x01\x00\x01\x003\x00\x00\x007\x00\x00\x00'
+        b'\x00\x00')
 
 class DecryptionTests(unittest.TestCase):
     """Check that ZIP decryption works. Since the library does not
@@ -2315,6 +2337,10 @@ class LzmaTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
                                      unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
+                                     unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 # Provide the tell() method but not seek()
 class Tellable:

--- a/test/test_zipfile2.py
+++ b/test/test_zipfile2.py
@@ -21,7 +21,7 @@ from random import randint, random, getrandbits
 from test.support import script_helper
 from test.support import (TESTFN, findfile, unlink, rmtree, temp_dir, temp_cwd,
                           requires_zlib, requires_bz2, requires_lzma,
-                          captured_stdout)
+                          requires_zstd, captured_stdout)
 
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"
@@ -804,6 +804,10 @@ class LzmaTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
                                 unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
+                                unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 class AbstractWriterTests:
 
@@ -846,6 +850,9 @@ class Bzip2WriterTests(AbstractWriterTests, unittest.TestCase):
 class LzmaWriterTests(AbstractWriterTests, unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdWriterTests(AbstractWriterTests, unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 @unittest.skipIf(sys.version_info[0:2] < (3, 5), 'Requires Python >= 3.5')
 class PyZipFileTests(unittest.TestCase):
@@ -1803,6 +1810,17 @@ class LzmaBadCrcTests(AbstractBadCrcTests, unittest.TestCase):
         b'ePK\x05\x06\x00\x00\x00\x00\x01\x00\x01\x003\x00\x00'
         b'\x00>\x00\x00\x00\x00\x00')
 
+@requires_zstd
+class ZstdBadCrcTests(AbstractBadCrcTests, unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
+    zip_with_bad_crc = (
+        b'PK\x03\x04?\x00\x00\x00]\x00\x00\x00!\x00V\xb1\x17J\x14\x00'
+        b'\x00\x00\x0b\x00\x00\x00\x05\x00\x00\x00afile(\xb5/\xfd\x00'
+        b'XY\x00\x00Hello WorldPK\x01\x02?\x03?\x00\x00\x00]\x00\x00\x00'
+        b'!\x00V\xb0\x17J\x14\x00\x00\x00\x0b\x00\x00\x00\x05\x00\x00\x00'
+        b'\x00\x00\x00\x00\x00\x00\x00\x00\x80\x01\x00\x00\x00\x00afilePK'
+        b'\x05\x06\x00\x00\x00\x00\x01\x00\x01\x003\x00\x00\x007\x00\x00\x00'
+        b'\x00\x00')
 
 class DecryptionTests(unittest.TestCase):
     """Check that ZIP decryption works. Since the library does not
@@ -1979,6 +1997,10 @@ class LzmaTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
                                      unittest.TestCase):
     compression = zipfile.ZIP_LZMA
 
+@requires_zstd
+class ZstdTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
+                                     unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
 
 # Provide the tell() method but not seek()
 class Tellable:

--- a/test/test_zipfile_aes.py
+++ b/test/test_zipfile_aes.py
@@ -8,6 +8,7 @@ from random import randint, random
 from test.support import unlink
 from .test_zipfile import (
     TESTFN, TESTFN2, Unseekable, get_files, requires_bz2, requires_zlib, requires_lzma,
+    requires_zstd,
 )
 
 from pyzipper import zipfile
@@ -374,6 +375,7 @@ class WZAESTests(unittest.TestCase):
             zipfile.ZIP_DEFLATED,
             zipfile.ZIP_BZIP2,
             zipfile.ZIP_LZMA,
+            zipfile.ZIP_ZSTANDARD,
         ]:
             for i in [1, 10, 19, 20, 200, 1000]:
                 with self.subTest(f"{compress_method}: content length: {i}"):
@@ -992,6 +994,13 @@ class WZAESLzmaTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
     pwd = b'this is a test password'
 
 
+@requires_pycrypto
+@requires_zstd
+class WZAESZstdTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
+                                          unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
+    encryption = zipfile_aes.WZ_AES
+    pwd = b'this is a test password'
 class AbstractTestZip64InSmallFiles:
     # These tests test the ZIP64 functionality without using large files,
     # see test_zipfile64 for proper tests.
@@ -1236,6 +1245,13 @@ class LzmaTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
     encryption_kwargs = {'nbits': 128}
     pwd = b'this is a test password'
 
+@requires_zstd
+class ZstdTestZip64InSmallFiles(AbstractTestZip64InSmallFiles,
+                                unittest.TestCase):
+    compression = zipfile.ZIP_ZSTANDARD
+    encryption = zipfile_aes.WZ_AES
+    encryption_kwargs = {'nbits': 128}
+    pwd = b'this is a test password'
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Port of https://github.com/python/cpython/commit/c273f59fb345877b3f752af9bcd45ed90aa90e1d

PR adds support for using zstd compression in zipfiles that are parsed by pyzipper. Given the relative simplicity of the upstream patch, the rising popularity of zstd for zipfiles, and that there's not really any great hooks to add this without monkey-patching or forking, I was hoping this could get merged, even though the rest of the API is largely pinned to Python 3.7.

With the change, was able to parse a test zip compressed with zstd:
```
>>> import zipfile
>>> z = zipfile.ZipFile('test.zip')
>>> z.infolist()
[<ZipInfo filename='Dockerfile' compress_type=zstd filemode='-rw-r--r--' external_attr=0x8020 file_size=1805 compress_size=910>]
>>> import pyzipper
>>> z = pyzipper.ZipFile('test.zip')
>>> z.infolist()
[<ZipInfo filename='Dockerfile' compress_type=zstd filemode='-rw-r--r--' external_attr=0x8020 file_size=1805 compress_size=910>]
```